### PR TITLE
Add Snapper compability

### DIFF
--- a/lib/Snapshot.php
+++ b/lib/Snapshot.php
@@ -76,6 +76,13 @@ class Snapshot {
 	}
 
 	public function getSnapshotDate() {
+		$info_file = realpath($this->path.'/../info.xml');
+		if (is_readable($info_file) && function_exists('simplexml_load_string') && function_exists('libxml_disable_entity_loader')) {
+			$dateFormat = "Y-m-d H:i:s";
+			$xml = simplexml_load_file($info_file);
+			$date = \DateTime::createFromFormat($dateFormat, $xml->date);
+			return $date;
+		}
 		return \DateTime::createFromFormat('*' . $this->dateFormat . '*', $this->getName() . '*');
 	}
 


### PR DESCRIPTION
Snapper does not create snapshots with the date in the name. The snapshots are only numbered. The date and some other information is stored in the info.xml next to the snapshot. This code reads the date from the info.xml file created by snapper.
For this plugin to work with the snapper structure you have to use something like "/data/.snapshots/%snapshot%/snapshot" as Snapshot format (where %snapshot% = 1,2,3,...).