### PR TITLE
Fixed date parsing + updated admin settings page

### DIFF
--- a/css/settings.scss
+++ b/css/settings.scss
@@ -1,20 +1,17 @@
 #files_snapshots {
-  table.settings {
-    width: 100%;
-    margin-bottom: 3em;
+  label span {
+      display: inline-block;
+      min-width: 175px;
+      padding: 8px 0px;
+      vertical-align: top;
+  }
 
-    td:first-child {
-      width: 200px;
-    }
+  input[type='text'] {
+    width: 400px;
+  }
 
-    td:nth-child(2) input {
-      width: 400px;
-      max-width: calc(100% - 10px);
-    }
-
-    input[type=submit] {
-      width: 100px;
-    }
+  div.settings {
+    margin-bottom: 30px;
   }
 
   table.result {

--- a/css/settings.scss
+++ b/css/settings.scss
@@ -8,6 +8,7 @@
 
   input[type='text'] {
     width: 400px;
+    max-width: calc(100% - 10px);
   }
 
   div.settings {

--- a/lib/Snapshot.php
+++ b/lib/Snapshot.php
@@ -76,7 +76,7 @@ class Snapshot {
 	}
 
 	public function getSnapshotDate() {
-		return \DateTime::createFromFormat('*' . $this->dateFormat . '*', $this->getName() . '*');
+		return \DateTime::createFromFormat($this->dateFormat, $this->getName());
 	}
 
 	public function readFile($file) {

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -5,47 +5,44 @@ style('files_snapshots', 'settings');
 /** @var \OCP\IL10N $l */
 /** @var array $_ */
 ?>
+
 <form id="files_snapshots" class="section" action="#" method="post">
 	<h2><?php p($l->t('Snapshots')); ?></h2>
-
-	<table class="settings">
-		<tbody>
-		<tr>
-			<td>
-				<label for="format">Snapshot format</label>
-			</td>
-			<td>
-				<input id="format" value="<?php p($_['snapshot_format']) ?>"
+	<p class="settings-hint"><?php p($l->t('Access filesystem snapshots from Nextcloud.')); ?></p>
+	<div class="settings">
+		<div>
+			<label>
+				<span><?php p($l->t('Snapshot format')); ?></span>
+				<input type="text" id="format"
+					   value="<?php p($_['snapshot_format']) ?>"
 					   placeholder="/path/to/snapshots/%snapshot%/data"/>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<label for="date_format">Date format</label>
-			</td>
-			<td>
-				<input id="date_format" value="<?php p($_['date_format']) ?>"/>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<input type="submit" value="Save"/>
-			</td>
-		</tr>
-		</tbody>
-	</table>
-	<h2>Discovered Snapshots</h2>
+			</label>
+		</div>
+		<div>
+			<label>
+				<span><?php p($l->t('Date format')); ?></span>
+				<input type="text"
+					   id="date_format" value="<?php p($_['date_format']) ?>"
+					   placeholder="Y-m-d_H:i:s"/>
+				<a target="_blank" rel="noreferrer noopener" class="icon-info" title="Open documentation" href="https://www.php.net/manual/en/datetime.createfromformat.php#refsect1-datetime.createfromformat-parameters"></a>
+			</label>
+		</div>
+		<div>
+			<input type="submit" value="<?php p($l->t('Save')); ?>"/>
+		</div>
+	</div>
+	<h2><?php p($l->t('Discovered Snapshots')); ?></h2>
 	<div class="loading"></div>
 	<table class="result grid hidden">
 		<thead>
-		<tr>
-			<th><?php p($l->t('Snapshot')); ?></th>
-			<th><?php p($l->t('Date')); ?></th>
-		</tr>
+			<tr>
+				<th><?php p($l->t('Snapshot')); ?></th>
+				<th><?php p($l->t('Date')); ?></th>
+			</tr>
 		</thead>
 		<tbody>
-		<tr>
-		</tr>
+			<tr>
+			</tr>
 		</tbody>
 	</table>
 </form>


### PR DESCRIPTION
### Fixed date parsing

`*` requires some bytes until the next separator. Therefore, snapshot names like `2019-08-20` are not recognized.

### Updated admin settings page

- Get rid of table layouts
- Added settings hint
- Added PHP documentation to write correct dateformat strings
- Make static strings translateable