### PR TITLE
Allow file globbing in the first part of the snapshot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ In order to access snapshots, two things need to be configured under the admin s
   example: `/srv/http/.zfs/snapshot/%snapshot%/nextcloud/data/`  
   where `/srv/http/nextcloud/data` is the Nextcloud data directory  
   and `/srv/http` is a folder which is being snapshoted to `/srv/http/.zfs/snapshot`.
+  
+  Additionally, if your snapshots are organized over multiple directories like
+  
+  ```
+  /.snapshots/hourly/2020-02-07_00:00/...
+  /.snapshots/hourly/2020-02-07_01:00/...
+  /.snapshots/daily/2020-02-06_00:00/...
+  /.snapshots/daily/2020-02-07_00:00/...
+  ```
+
+  you can use a glob such as `/.snapshots/*/%snapshot%/` to make the app search for snapshots in multiple directories.
    
 - snapshot folder date format: How the snapshot date is formatted in the snapshot name
 

--- a/lib/SnapshotManager.php
+++ b/lib/SnapshotManager.php
@@ -55,14 +55,16 @@ class SnapshotManager {
 		if ($this->snapshotPrefix === null) {
 			return;
 		}
-		$dh = opendir($this->snapshotPrefix);
-		while ($file = readdir($dh)) {
-			$path = $this->snapshotPrefix . '/' . $file;
-			if ($file[0] !== '.' && is_dir($path) && is_dir($path . '/' . $this->snapshotPostfix)) {
-				yield new Snapshot($path . '/' . $this->snapshotPostfix, $file, $this->dateFormat);
+		foreach (glob($this->snapshotPrefix, GLOB_ONLYDIR) as $dir) {
+			$dh = opendir($dir);
+			while ($file = readdir($dh)) {
+				$path = $dir . '/' . $file;
+				if ($file[0] !== '.' && is_dir($path) && is_dir($path . '/' . $this->snapshotPostfix)) {
+					yield new Snapshot($path . '/' . $this->snapshotPostfix, $file, $this->dateFormat);
+				}
 			}
+			closedir($dh);
 		}
-		closedir($dh);
 	}
 
 	/**


### PR DESCRIPTION
I organize my snapshots in directories like this:
```
/.snapshots/hourly/2020-02-07_00:00/...
/.snapshots/hourly/2020-02-07_01:00/...
/.snapshots/daily/2020-02-06_00:00/...
/.snapshots/daily/2020-02-07_00:00/...
```
files_snapshots currently only allows me to select one of these directories, thus not making all snapshots available to the user.

I changed `listAllSnapshots` to allow using file globbing patterns in the prefix part. This allows setting `snap_format` to `/.snapshots/*/%snapshot%/...` and access all snapshots via Nextcloud.

Note: This would break compatibility for people using globbing characters (`*`, `?`, `[...]`) in their actual path names. However, I do not expect anyone to do that, since it seems like asking for trouble to me.